### PR TITLE
fix: use path.resolve(), tidy output, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,21 +110,32 @@ If this function is not defined, then no setup code will be run.
 
 #### createTests
 
-The `createTests` function takes a Puppeteer [page][] as input and returns an array of plain objects representing the tests to run, and the data to pass for each one. This is useful if you want to dynamically determine what tests to run against a page (for instance, which links to click).
+The `createTests` function takes a Puppeteer [page][] as input and returns an array of _test data objects_ representing the tests to run, and the data to pass for each one. This is useful if you want to dynamically determine what tests to run against a page (for instance, which links to click).
 
-If this function is not defined, then the default tests are `[{}]` (a single test with empty data).
+If `createTests` is not defined, then the default tests are `[{}]` (a single test with empty data).
 
-If you would like a nice description to be printed to the CLI while running the test, you can add a `description` property to the test data:
+The basic shape for a test data object is like so:
+
+```json
+{
+  "description": "Some human-readable description",
+  "data": {
+    "some data": "which is passed to the test"
+  }
+}
+```
+
+For instance, your `createTests` might return:
 
 ```json
 [
   {
     "description": "My test 1",
-    "foo": "foo"
+    "data": { "foo": "foo" }
   },
   {
     "description": "My test 2",
-    "foo": "bar"
+    "data": { "foo": "bar" }
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ The `createTests` function takes a Puppeteer [page][] as input and returns an ar
 
 If this function is not defined, then the default tests are `[{}]` (a single test with empty data).
 
+If you would like a nice description to be printed to the CLI while running the test, you can add a `description` property to the test data:
+
+```json
+[
+  {
+    "description": "My test 1",
+    "foo": "foo"
+  },
+  {
+    "description": "My test 2",
+    "foo": "bar"
+  }
+]
+```
+
 #### iteration
 
 The `iteration` function takes a Puppeteer [page][] and _iteration data_ as input and returns undefined. It runs for each iteration of the memory leak test. The _iteration data_ is a plain object and comes from the `createTests` function, so by default it is just an empty object: `{}`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,7 +37,7 @@ async function main () {
   const { signal } = controller
   let scenario
   if (options.scenario) {
-    scenario = await import(path.join(process.cwd(), options.scenario))
+    scenario = await import(path.resolve(process.cwd(), options.scenario))
   }
 
   console.log('\n' + `

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ export async function * findLeaks (pageUrl, options = {}) {
 
   const runIteration = async (test, i, numTests) => {
     try {
-      const prefix = `Test ${i + 1}/${numTests} - ${test.description} -`
+      const prefix = `Test ${i + 1}/${numTests}${test.description ? ` - ${test.description}` : ''} -`
       return (await runWithSpinner(progress, async (onProgress) => {
         const onProgressWithPrefix = message => {
           onProgress(`${prefix} ${message}`)


### PR DESCRIPTION
Realized I should be using path.resolve, not path.join, since it won't support absolute paths. Also the output was kind of ugly for custom scenarios. And I realized the docs were wrong for `createTests`.