### PR TITLE
feat: add --setup flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
 
     fuite <url>
 
-The URL to load. This should be whatever landing page you want to start at – you can use the `setup` option in a custom [scenario](#scenario) if you need to log in.
+The URL to load. This should be whatever landing page you want to start at. Note that you can use [`--setup`](#setup) for a custom setup function (e.g. to log in with a username/password).
 
 ## Output
 
@@ -106,7 +106,7 @@ Your `myScenario.mjs` can export several `async function`s. Here's what they do:
 
 ### `setup` function
 
-The `setup` function takes a Puppeteer [page][] as input and returns undefined. It runs before each `iteration`, or before `createTests`. This is a good place to log in, if your webapp requires a login.
+The `setup` function takes a Puppeteer [Page][] as input and returns undefined. It runs before each `iteration`, or before `createTests`. This is a good place to log in, if your webapp requires a login.
 
 If this function is not defined, then no setup code will be run.
 
@@ -114,7 +114,7 @@ Note that there is also a [`--setup` flag](#setup) flag. If defined, it will ove
 
 ### `createTests` function
 
-The `createTests` function takes a Puppeteer [page][] as input and returns an array of _test data objects_ representing the tests to run, and the data to pass for each one. This is useful if you want to dynamically determine what tests to run against a page (for instance, which links to click).
+The `createTests` function takes a Puppeteer [Page][] as input and returns an array of _test data objects_ representing the tests to run, and the data to pass for each one. This is useful if you want to dynamically determine what tests to run against a page (for instance, which links to click).
 
 If `createTests` is not defined, then the default tests are `[{}]` (a single test with empty data).
 
@@ -146,7 +146,7 @@ For instance, your `createTests` might return:
 
 ### `iteration` function
 
-The `iteration` function takes a Puppeteer [page][] and _iteration data_ as input and returns undefined. It runs for each iteration of the memory leak test. The _iteration data_ is a plain object and comes from the `createTests` function, so by default it is just an empty object: `{}`.
+The `iteration` function takes a Puppeteer [Page][] and _iteration data_ as input and returns undefined. It runs for each iteration of the memory leak test. The _iteration data_ is a plain object and comes from the `createTests` function, so by default it is just an empty object: `{}`.
 
 Inside of an `iteration`, you want to run the core test logic that you want to test for leaks. The idea is that, at the beginning of the iteration and at the end, the memory _should_ be the same.  So an iteration might do things like:
 
@@ -161,7 +161,7 @@ The iteration assumes that whatever page it starts at, it ends up at that same p
 
     --setup <setup>
 
-The `--setup` flag can define a custom `setup` function. This is useful for overriding the `setup` function in the default scenario.
+The `--setup` option can define a custom `setup` function, which runs immediately after the page is loaded, but before any other scenario code.
 
 For instance, you can use `--setup` to log in with a username/password. To do so, first create a file called `mySetup.mjs`:
 
@@ -179,7 +179,7 @@ Then pass it in:
 npx fuite https://example.com --setup ./mySetup.mjs
 ```
 
-The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario [`--scenario`](#scenario).
+The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario ([`--scenario`](#scenario)).
 
 If both `--scenario` and `--setup` are defined, then `--setup` will override the `setup` function in the scenario.
 
@@ -230,7 +230,7 @@ This returns the same output you would get using `--output <filename>` in the CL
 
 ## Options
 
-The options for `findLeaks` are basically the same as for the CLI. The only differences between this API and the CLI are:
+The options for `findLeaks` are basically the same as for the CLI. The only differences between the JavaScript API and the CLI are:
 
 - `scenario` takes an object with keys `setup`, `createTests`, and `iteration` rather than a filename (see [Scenario object](#scenario-object) and [Extending the default scenario](#extending-the-default-scenario)).
 - `progress` can be set to `false` to disable the progress spinner.
@@ -368,4 +368,4 @@ Currently `fuite` requires Chromium-specific tools such as heap snapshots, `getE
 
 That said, if something is leaking in Chrome, it's likely leaking in Safari and Firefox too.
 
-[page]: https://pptr.dev/#?product=Puppeteer&version=v12.0.1&show=api-class-page
+[Page]: https://pptr.dev/#?product=Puppeteer&version=v12.0.1&show=api-class-page

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ For the JavaScript API, you can pass in a custom scenario as a plain object. Fir
 const myScenario = {
   async setup(page) { /* ... */ },
   async createTests(page) { /* ... */ },
-  async iteration(page, options) { /* ... */ }
+  async iteration(page, data) { /* ... */ }
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Then pass it in:
 npx fuite https://example.com --setup ./mySetup.mjs
 ```
 
-The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario ([`--scenario`](#scenario)).
+The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario ([`--scenario`](#scenario)) (i.e. it takes a Puppeteer [Page][] as input).
 
 If both `--scenario` and `--setup` are defined, then `--setup` will override the `setup` function in the scenario.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Then pass it in:
 npx fuite https://example.com --setup ./mySetup.mjs
 ```
 
-The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario ([`--scenario`](#scenario)) (i.e. it takes a Puppeteer [Page][] as input).
+The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario using [`--scenario`](#scenario) (i.e. it takes a Puppeteer [Page][] as input).
 
 If both `--scenario` and `--setup` are defined, then `--setup` will override the `setup` function in the scenario.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The options for `findLeaks` are basically the same as for the CLI. The only diff
 
 ### Cancel the test
 
-You can also pass in an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as the `signal` option to cancel the test on-demand:
+You can pass in an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as the `signal` option to cancel the test on-demand:
 
 ```js
 const controller = new AbortController();

--- a/README.md
+++ b/README.md
@@ -77,18 +77,18 @@ By default, `fuite` runs 7 iterations. But you can change this number.
 
 Why 7? Well, it's a nice, small, prime number. If you repeat an action 7 times and some object is leaking exactly 7 times, it's pretty unlikely to be unrelated. That said, on a very complex page, there may be enough noise that 7 is too small to cut through the noise – so you might try 13, 17, or 19 instead. Or 1 if you like to live dangerously.
 
-## Scenarios
+## Scenario
 
     --scenario <scenario>
 
 The default scenario is to find all internal links on the page, click them, and press the back button. You can also define a scenario file that does whatever you want:
 
 ```bash
-fuite --scenario ./myScenario.js https://example.com
+fuite --scenario ./myScenario.mjs https://example.com
 ```
 
 ```js
-// myScenario.js
+// myScenario.mjs
 export async function setup(page) {
   // Setup code to run before each test
 }
@@ -102,15 +102,17 @@ export async function iteration(page, data) {
 }
 ```
 
-Your `myScenario.js` can export several `async function`s. Here's what they do:
+Your `myScenario.mjs` can export several `async function`s. Here's what they do:
 
-### setup
+### `setup` function
 
 The `setup` function takes a Puppeteer [page][] as input and returns undefined. It runs before each `iteration`, or before `createTests`. This is a good place to log in, if your webapp requires a login.
 
 If this function is not defined, then no setup code will be run.
 
-### createTests
+Note that there is also a [`--setup` flag](#setup) flag. If defined, it will override the `setup` function defined in a scenario.
+
+### `createTests` function
 
 The `createTests` function takes a Puppeteer [page][] as input and returns an array of _test data objects_ representing the tests to run, and the data to pass for each one. This is useful if you want to dynamically determine what tests to run against a page (for instance, which links to click).
 
@@ -142,7 +144,7 @@ For instance, your `createTests` might return:
 ]
 ```
 
-### iteration
+### `iteration` function
 
 The `iteration` function takes a Puppeteer [page][] and _iteration data_ as input and returns undefined. It runs for each iteration of the memory leak test. The _iteration data_ is a plain object and comes from the `createTests` function, so by default it is just an empty object: `{}`.
 
@@ -155,42 +157,31 @@ Inside of an `iteration`, you want to run the core test logic that you want to t
 
 The iteration assumes that whatever page it starts at, it ends up at that same page. If you test a multi-page app in this way, then it's extremely unlikely you'll detect any leaks, since multi-page apps don't leak memory in the same way that SPAs do when navigating between routes.
 
-### Extending the default scenario in the CLI
+## Setup
 
-You can also extend the default scenario, e.g. to add a `setup` step that logs the user in. To do so, you must first install `fuite` in a local Node project. If you don't have one, run:
+    --setup <setup>
 
-```shell
-mkdir my-project
-cd my-project
-npm init --yes
-```
+The `--setup` flag can define a custom `setup` function. This is useful for overriding the `setup` function in the default scenario.
 
-Once you have your project, run:
-
-```shell
-npm i --save-dev fuite
-```
-
-Then create a file called `customScenario.mjs`:
+For instance, you can use `--setup` to log in with a username/password. To do so, first create a file called `mySetup.mjs`:
 
 ```js
-import { defaultScenario } from 'fuite'
-const { createTests, iteration } = defaultScenario
-
-async function setup (page) {
-  await (await page.$('#username')).type('myusername')
-  await (await page.$('#password')).type('mypassword')
-  await (await page.$('#submit')).click()
+export async function setup (page) {
+  await page.type('#username', 'myusername');
+  await page.type('#password', 'mypassword');
+  await page.click('#submit');
 }
-
-export { createTests, iteration, setup }
 ```
 
-Then run:
+Then pass it in:
 
 ```shell
-npx fuite https://example.com --scenario ./customScenario.mjs
+npx fuite https://example.com --setup ./mySetup.mjs
 ```
+
+The [`setup` function](#setup-function) defined here is the same one that you can define in a custom scenario [`--scenario`](#scenario).
+
+If both `--scenario` and `--setup` are defined, then `--setup` will override the `setup` function in the scenario.
 
 ## Heap snapshot
 
@@ -219,15 +210,17 @@ This will launch Chrome in non-headless mode, and it will also automatically pau
 `fuite` can also be used via a JavaScript API, which works similarly to the CLI:
 
 ```js
-import { findLeaks } from 'fuite'
+import { findLeaks } from 'fuite';
 
 const results = findLeaks('https://example.com', {
   scenario: scenarioObject,
+  iterations: 7,
   heapsnapshot: false,
-  debug: false
-})
+  debug: false,
+  progress: true
+});
 for await (const result of results) {
-  console.log(result)
+  console.log(result);
 }
 ```
 
@@ -235,7 +228,18 @@ Note that `findLeaks` returns an [async iterable](https://developer.mozilla.org/
 
 This returns the same output you would get using `--output <filename>` in the CLI – a plain object describing the leak. The format of the object is not fully specified yet, but a basic shape can be found in [the TypeScript types](https://github.com/nolanlawson/fuite/blob/master/types/index.d.ts).
 
-You can also pass in an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to cancel the test on-demand:
+## Options
+
+The options for `findLeaks` are basically the same as for the CLI. The only differences between this API and the CLI are:
+
+- `scenario` takes an object with keys `setup`, `createTests`, and `iteration` rather than a filename (see [Scenario object](#scenario-object) and [Extending the default scenario](#extending-the-default-scenario)).
+- `progress` can be set to `false` to disable the progress spinner.
+- `setup` is not supported – use `scenario` instead
+- `signal` can be used to cancel the test (see [Cancel the test](#cancel-the-test))
+
+### Cancel the test
+
+You can also pass in an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) as the `signal` option to cancel the test on-demand:
 
 ```js
 const controller = new AbortController();
@@ -246,12 +250,36 @@ findLeaks('https://example.com', { signal });
 controller.abort();
 ```
 
-## Extending the default scenario
+## Scenario object
 
-If you're writing your own custom scenario, you can also extend the default scenario. For instance, if you want the default scenario, but to be able to log in with a username and password:
+For the JavaScript API, you can pass in your own custom scenario defined as a plain object:
 
 ```js
-import { defaultScenario, findLeaks } from 'fuite'
+const myScenario = {
+  async setup(page) { /* ... */ },
+  async createTests(page) { /* ... */ },
+  async iteration(page, options) { /* ... */ }
+};
+```
+
+Then pass it in:
+
+```js
+import { findLeaks } from 'fuite';
+
+for await (const result of findLeaks('https://example.com', {
+  scenario: myScenario
+})) {
+  console.log(result);
+}
+```
+
+### Extending the default scenario
+
+If you're writing your own custom scenario, you can also extend the default scenario. For instance, if you want the default scenario, but to be able to log in with a username and password first:
+
+```js
+import { defaultScenario, findLeaks } from 'fuite';
 
 const myScenario = {
   ...defaultScenario,
@@ -260,14 +288,16 @@ const myScenario = {
     await page.type('#password', 'mypassword')
     await page.click('#submit')
   }
-}
+};
 
-await findLeaks('https://example.com', {
+for await (const result of findLeaks('https://example.com', {
   scenario: myScenario
-})
+})) {
+  console.log(result);
+}
 ```
 
-Note that the above works if you're using the JavaScript API. For the CLI, see [extending the default scenario in the CLI](#extending-the-default-scenario-in-the-cli).
+Note that the above works if you're using the JavaScript API. For the CLI, you probably want to use [the `--setup` flag](#setup).
 
 # Limitations
 
@@ -322,11 +352,11 @@ One technique is to override the object's methods to check whenever it's called:
 
 ```js
 for (const prop of ['push', 'concat', 'unshift', 'splice']) {
-  const original = array[prop]
+  const original = array[prop];
   array[prop] = function () {
-    debugger
-    return array[prop].apply(this, arguments)
-  }
+    debugger;
+    return array[prop].apply(this, arguments);
+  };
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ for (const prop of ['push', 'concat', 'unshift', 'splice']) {
   const original = array[prop];
   array[prop] = function () {
     debugger;
-    return array[prop].apply(this, arguments);
+    return original.apply(this, arguments);
   };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ controller.abort();
 
 ## Scenario object
 
-For the JavaScript API, you can pass in your own custom scenario defined as a plain object:
+For the JavaScript API, you can pass in a custom scenario as a plain object. First, define it:
 
 ```js
 const myScenario = {
@@ -273,6 +273,8 @@ for await (const result of findLeaks('https://example.com', {
   console.log(result);
 }
 ```
+
+If `scenario` is undefined, then the default scenario will be used.
 
 ### Extending the default scenario
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ This returns the same output you would get using `--output <filename>` in the CL
 
 The options for `findLeaks` are basically the same as for the CLI. The only differences between the JavaScript API and the CLI are:
 
-- `scenario` takes an object with keys `setup`, `createTests`, and `iteration` rather than a filename (see [Scenario object](#scenario-object) and [Extending the default scenario](#extending-the-default-scenario)).
+- `scenario` takes an object with keys `setup`, `createTests`, and `iteration` rather than a filename (see [Scenario object](#scenario-object) and [Extending the default scenario](#extending-the-default-scenario) below).
 - `progress` can be set to `false` to disable the progress spinner.
-- `setup` is not supported – use `scenario` instead
-- `signal` can be used to cancel the test (see [Cancel the test](#cancel-the-test))
+- `setup` is not supported – use `scenario` instead.
+- `signal` can be used to cancel the test (see [Cancel the test](#cancel-the-test) below).
 
 ### Cancel the test
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 import exitHook from 'exit-hook'
-import { DEFAULT_ITERATIONS, findLeaks } from './index.js'
+import { DEFAULT_ITERATIONS, defaultScenario, findLeaks } from './index.js'
 import { Command } from 'commander'
 import { createRequire } from 'module'
 import path from 'path'
@@ -23,6 +23,7 @@ program
   .option('-i, --iterations <number>', 'Number of iterations', DEFAULT_ITERATIONS)
   .option('-H, --heapsnapshot', 'Save heapsnapshot files')
   .option('-s, --scenario <scenario>', 'Scenario file to run')
+  .option('-S, --setup <setup>', 'Setup function to run (e.g. in the default scenario)')
   .option('-d, --debug', 'Run in debug mode')
   .option('-p, --progress', 'Show progress spinner (--no-progress to disable)', true)
   .version(version)
@@ -38,6 +39,16 @@ async function main () {
   let scenario
   if (options.scenario) {
     scenario = await import(path.resolve(process.cwd(), options.scenario))
+  } else {
+    scenario = defaultScenario
+  }
+  if (options.setup) {
+    // override whatever setup function is defined on the scenario
+    const { setup } = await import(path.resolve(process.cwd(), options.setup))
+    scenario = {
+      ...scenario,
+      setup
+    }
   }
 
   console.log('\n' + `

--- a/test/spec/cli.mjs
+++ b/test/spec/cli.mjs
@@ -1,0 +1,75 @@
+import { createTempFile, runCli } from './util.js'
+import { expect } from 'chai'
+import fs from 'fs/promises'
+
+describe('cli test suite', () => {
+  it('minimal cli test', async () => {
+    const results = await runCli(['http://localhost:3000/test/www/minimal/'])
+
+    expect(results.length).to.equal(1)
+    const { result } = results[0]
+    expect(result.leaks.detected).to.equal(true)
+
+    expect(result.deltaPerIteration).to.be.above(1000000)
+    expect(result.deltaPerIteration).to.be.below(2000000)
+
+    const leak = result.leaks.objects.find(_ => _.name === 'SomeBigObject')
+    expect(leak.retainedSizeDeltaPerIteration).to.be.above(1000000)
+    expect(leak.retainedSizeDeltaPerIteration).to.be.below(2000000)
+  })
+
+  it('custom setup function', async () => {
+    const tempFile = createTempFile('mjs')
+    const fileContents = `
+      export async function setup(page) {
+        await (await page.$('#username')).type('myusername')
+        await (await page.$('#password')).type('mypassword')
+        await (await page.$('#submit')).click()
+      }
+    `
+    await fs.writeFile(tempFile, fileContents, 'utf8')
+
+    const results = await runCli(['http://localhost:3000/test/www/login/', `--setup=${tempFile}`])
+
+    expect(results.length).to.equal(1)
+    const { result } = results[0]
+    expect(result.leaks.detected).to.equal(true)
+
+    expect(result.deltaPerIteration).to.be.above(1000000)
+    expect(result.deltaPerIteration).to.be.below(2000000)
+
+    const leak = result.leaks.objects.find(_ => _.name === 'SomeBigObject')
+    expect(leak.retainedSizeDeltaPerIteration).to.be.above(1000000)
+    expect(leak.retainedSizeDeltaPerIteration).to.be.below(2000000)
+  })
+
+  it('custom scenario', async () => {
+    const tempFile = createTempFile('mjs')
+    const fileContents = `
+        export async function setup(page) {
+          await page.type('#username', 'myusername')
+          await page.type('#password', 'mypassword')
+          await page.click('#submit')
+        }
+        
+        export async function iteration(page) {
+          await page.click('a[href="info"]')
+          await page.goBack()
+        }
+      `
+    await fs.writeFile(tempFile, fileContents, 'utf8')
+
+    const results = await runCli(['http://localhost:3000/test/www/login/', `--scenario=${tempFile}`])
+
+    expect(results.length).to.equal(1)
+    const { result } = results[0]
+    expect(result.leaks.detected).to.equal(true)
+
+    expect(result.deltaPerIteration).to.be.above(1000000)
+    expect(result.deltaPerIteration).to.be.below(2000000)
+
+    const leak = result.leaks.objects.find(_ => _.name === 'SomeBigObject')
+    expect(leak.retainedSizeDeltaPerIteration).to.be.above(1000000)
+    expect(leak.retainedSizeDeltaPerIteration).to.be.below(2000000)
+  })
+})

--- a/test/spec/util.js
+++ b/test/spec/util.js
@@ -1,7 +1,42 @@
+import { spawn } from 'child_process'
+import path from 'path'
+import url from 'url'
+import tempDir from 'temp-dir'
+import cryptoRandomString from 'crypto-random-string'
+import fs from 'fs/promises'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
 export async function asyncIterableToArray (iterable) {
   const res = []
   for await (const item of iterable) {
     res.push(item)
   }
   return res
+}
+
+export function createTempFile (extension) {
+  return path.join(tempDir, `fuite-tmp-${cryptoRandomString({ length: 8, type: 'alphanumeric' })}.${extension}`)
+}
+
+export async function runCli (args) {
+  const binPath = path.join(__dirname, '../../src/cli.cjs')
+  const tempFile = createTempFile('json')
+  args = [...args, `--output=${tempFile}`]
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(binPath, args)
+
+    // for debugging
+    // child.stderr.pipe(process.stderr)
+    // child.stdout.pipe(process.stdout)
+
+    child.on('close', code => {
+      if (code !== 0) {
+        return reject(new Error(`Child process exited with code ${code}`))
+      }
+      return resolve()
+    })
+  })
+  return JSON.parse(await fs.readFile(tempFile, 'utf8'))
 }


### PR DESCRIPTION
Fixes #12

Adds a new flag, `--setup`, that is used to override the scenario's `setup` function. This should hopefully address the very common use case of "I want to use the default scenario, but I want to log in with a username/password first."