### PR TITLE
fix: better handle changing dom node descriptions

### DIFF
--- a/src/analyzeDomNodes.js
+++ b/src/analyzeDomNodes.js
@@ -16,7 +16,10 @@ export function analyzeDomNodes (nodesBefore, nodesAfter, numIterations) {
   descriptionToCountsAfter.forEach((countAfter, description) => {
     const countBefore = descriptionToCountsBefore.get(description) || 0
     const delta = countAfter - countBefore
-    if (delta > 0) {
+    // for dom nodes, we ignore any that are "randomly" leaking, i.e. leaking some number that is
+    // not the same as the number of iterations, because recycled DOM nodes may change their id/classes,
+    // leading to dom nodes like div#NTk4NzE4 being "leaked" 0.1428 times
+    if (delta > 0 && delta % numIterations === 0) {
       result.push({
         description,
         before: countBefore,

--- a/test/spec/domNodes.test.mjs
+++ b/test/spec/domNodes.test.mjs
@@ -80,14 +80,14 @@ describe('dom nodes', () => {
     expect(result.after.domNodes.count).to.equal(18)
 
     expect(result.leaks.domNodes.nodes).to.deep.equal([
-        {
-          description: 'div.actually-leaking',
-          before: 1,
-          after: 4,
-          delta: 3,
-          deltaPerIteration: 1
-        }
-      ]
+      {
+        description: 'div.actually-leaking',
+        before: 1,
+        after: 4,
+        delta: 3,
+        deltaPerIteration: 1
+      }
+    ]
     )
   })
 })

--- a/test/spec/eventListeners.test.mjs
+++ b/test/spec/eventListeners.test.mjs
@@ -211,4 +211,44 @@ describe('event listeners', () => {
       }
     ])
   })
+
+  it('can ignore recycled event listener names', async () => {
+    const results = await asyncIterableToArray(findLeaks('http://localhost:3000/test/www/recyclesEventListeners/', {
+      iterations: 3
+    }))
+
+    expect(results.length).to.equal(1)
+    expect(results.map(_ => ({ href: _.test.data.href }))).to.deep.equal([
+      { href: 'about' }
+    ])
+    const result = results[0].result
+    expect(result.leaks.detected).to.equal(false)
+    expect(result.leaks.eventListeners).to.deep.equal([])
+    expect(result.leaks.eventListenersSummary).to.deep.equal({
+      before: 6,
+      after: 6,
+      delta: 0,
+      deltaPerIteration: 0
+    })
+  })
+
+  it('can ignore recycled event listener names where the dom node is constantly changing IDs', async () => {
+    const results = await asyncIterableToArray(findLeaks('http://localhost:3000/test/www/recyclesEventListenersNewNodeIds/', {
+      iterations: 3
+    }))
+
+    expect(results.length).to.equal(1)
+    expect(results.map(_ => ({ href: _.test.data.href }))).to.deep.equal([
+      { href: 'about' }
+    ])
+    const result = results[0].result
+    expect(result.leaks.detected).to.equal(false)
+    expect(result.leaks.eventListeners).to.deep.equal([])
+    expect(result.leaks.eventListenersSummary).to.deep.equal({
+      before: 6,
+      after: 6,
+      delta: 0,
+      deltaPerIteration: 0
+    })
+  })
 })

--- a/test/www/recyclesDomNodesNewIds/index.html
+++ b/test/www/recyclesDomNodesNewIds/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  const createRecycledElement = () => {
+    const el = document.createElement('span')
+    el.id = `rando-${btoa(Math.round(Math.random() * 1000000).toString())}`
+    el.addEventListener('mouseleave', function onMouseLeave () {})
+    return el
+  }
+
+  // do 3 iterations because our test will also do 3 iterations
+  const ITERATIONS = 3
+  for (let i = 0; i < ITERATIONS; i++) {
+    document.body.appendChild(createRecycledElement())
+  }
+
+  router.addAfterHook('/about', () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      document.body.removeChild(document.querySelector('span'))
+    }
+    for (let i = 0; i < ITERATIONS; i++) {
+      document.body.appendChild(createRecycledElement())
+    }
+  })
+</script>
+</body>
+</html>

--- a/test/www/recyclesDomNodesNewIdsAndActualLeak/index.html
+++ b/test/www/recyclesDomNodesNewIdsAndActualLeak/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  const createRecycledElement = () => {
+    const el = document.createElement('span')
+    el.id = `rando-${btoa(Math.round(Math.random() * 1000000).toString())}`
+    el.addEventListener('mouseleave', function onMouseLeave () {})
+    return el
+  }
+
+  // do 3 iterations because our test will also do 3 iterations
+  const ITERATIONS = 3
+  for (let i = 0; i < ITERATIONS; i++) {
+    document.body.appendChild(createRecycledElement())
+  }
+
+  router.addAfterHook('/about', () => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      document.body.removeChild(document.querySelector('span'))
+    }
+    for (let i = 0; i < ITERATIONS; i++) {
+      document.body.appendChild(createRecycledElement())
+    }
+    // actual leak
+    const div = document.createElement('div')
+    div.className = 'actually-leaking'
+    document.body.appendChild(div)
+  })
+</script>
+</body>
+</html>

--- a/test/www/recyclesEventListeners/index.html
+++ b/test/www/recyclesEventListeners/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  const cleanups = []
+
+  const createRecycledListener = () => {
+    const name = `fake-${btoa(Math.round(Math.random() * 1000000).toString())}`
+
+    const listener = () => {}
+    document.addEventListener(name, listener)
+    cleanups.push(() => document.removeEventListener(name, listener))
+  }
+
+  router.addAfterHook('/about', () => {
+    while (cleanups.length) {
+      cleanups.shift()()
+    }
+    for (let i = 0; i < 3; i++) { // do 3 iterations because that's how many the test does
+      createRecycledListener()
+    }
+  })
+</script>
+</body>
+</html>

--- a/test/www/recyclesEventListenersNewNodeIds/index.html
+++ b/test/www/recyclesEventListenersNewNodeIds/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  const createRecycledListener = () => {
+    const id = `fake-${btoa(Math.round(Math.random() * 1000000).toString())}`
+    const name = `fake-${btoa(Math.round(Math.random() * 1000000).toString())}`
+
+    const listener = () => {}
+    const span = document.createElement('span')
+    span.id = id
+    span.addEventListener(name, listener)
+    document.body.appendChild(span)
+  }
+
+  router.addAfterHook('/about', () => {
+    while (document.querySelector('span')) {
+      document.body.removeChild(document.querySelector('span'))
+    }
+    for (let i = 0; i < 3; i++) { // do 3 iterations because that's how many the test does
+      createRecycledListener()
+    }
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
If a DOM node is constantly being recycled, but with a different ID every time, then we can detect a "leak" that doesn't exist. This fixes that.