### PR TITLE
fix: handle changing event/node names

### DIFF
--- a/src/analyzeDomNodes.js
+++ b/src/analyzeDomNodes.js
@@ -14,12 +14,14 @@ export function analyzeDomNodes (nodesBefore, nodesAfter, numIterations) {
   const descriptionToCountsAfter = createDescriptionToCounts(nodesAfter)
 
   descriptionToCountsAfter.forEach((countAfter, description) => {
-    const countBefore = descriptionToCountsBefore.get(description) || 0
+    if (!descriptionToCountsBefore.has(description)) {
+      // ignore any dom nodes that didn't exist before, because recycled DOM nodes may change their id/classes,
+      // leading to dom nodes like div#NTk4NzE4 being "leaked" 0.1428 times
+      return
+    }
+    const countBefore = descriptionToCountsBefore.get(description)
     const delta = countAfter - countBefore
-    // for dom nodes, we ignore any that are "randomly" leaking, i.e. leaking some number that is
-    // not the same as the number of iterations, because recycled DOM nodes may change their id/classes,
-    // leading to dom nodes like div#NTk4NzE4 being "leaked" 0.1428 times
-    if (delta > 0 && delta % numIterations === 0) {
+    if (delta > 0) {
       result.push({
         description,
         before: countBefore,

--- a/src/format.js
+++ b/src/format.js
@@ -40,6 +40,11 @@ function formatLeakingEventListeners (listenerSummaries, eventListenersSummary) 
       nodesFormatted
     ])
   }
+
+  if (tableData.length === 1) { // no individual breakdowns, so just put the total
+    tableData.push(['Total', eventListenersSummary.deltaPerIteration, '(Unknown)'])
+  }
+
   return `
 Leaking event listeners (+${eventListenersSummary.deltaPerIteration} total):
 
@@ -59,6 +64,11 @@ function formatLeakingDomNodes (domNodes) {
       deltaPerIteration
     ])
   }
+
+  if (tableData.length === 1) { // no individual breakdowns, so just put the total
+    tableData.push(['Total', domNodes.deltaPerIteration])
+  }
+
   return `
 Leaking DOM nodes (+${domNodes.deltaPerIteration} total):
 
@@ -101,7 +111,7 @@ export function formatResult ({ test, result }) {
   if (result.leaks.objects.length) {
     leakTables += formatLeakingObjects(result.leaks.objects)
   }
-  if (result.leaks.eventListeners.length) {
+  if (result.leaks.eventListenersSummary.delta > 0) {
     leakTables += formatLeakingEventListeners(result.leaks.eventListeners, result.leaks.eventListenersSummary)
   }
   if (result.leaks.domNodes.delta > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -135,8 +135,8 @@ export async function * findLeaks (pageUrl, options = {}) {
         const leaksDetected = Boolean(
           deltaPerIteration > 0 && (
             leakingObjects.length ||
-            leakingListeners.length ||
-            leakingDomNodes.length ||
+            (eventListenersSummary.delta > 0) ||
+            ((domNodesEnd.length - domNodesStart.length) > 0) ||
             leakingCollections.length
           )
         )

--- a/src/index.js
+++ b/src/index.js
@@ -146,8 +146,6 @@ export async function * findLeaks (pageUrl, options = {}) {
           )
         )
 
-
-
         const result = {
           delta,
           deltaPerIteration,

--- a/src/index.js
+++ b/src/index.js
@@ -130,16 +130,23 @@ export async function * findLeaks (pageUrl, options = {}) {
         const leakingListeners = analyzeEventListeners(eventListenersStart, eventListenersEnd, numIterations)
         const eventListenersSummary = calculateEventListenersSummary(eventListenersStart, eventListenersEnd, numIterations)
         const leakingDomNodes = analyzeDomNodes(domNodesStart, domNodesEnd, numIterations)
+        const domNodesSummary = {
+          delta: domNodesEnd.length - domNodesStart.length,
+          deltaPerIteration: (domNodesEnd.length - domNodesStart.length) / numIterations,
+          nodes: leakingDomNodes
+        }
         const delta = endStatistics.total - startStatistics.total
         const deltaPerIteration = Math.round(delta / numIterations)
         const leaksDetected = Boolean(
           deltaPerIteration > 0 && (
             leakingObjects.length ||
             (eventListenersSummary.delta > 0) ||
-            ((domNodesEnd.length - domNodesStart.length) > 0) ||
+            (domNodesSummary.delta > 0) ||
             leakingCollections.length
           )
         )
+
+
 
         const result = {
           delta,
@@ -150,11 +157,7 @@ export async function * findLeaks (pageUrl, options = {}) {
             objects: leakingObjects,
             eventListeners: leakingListeners,
             eventListenersSummary, // eventListenersSummary is a separate object for backwards compat
-            domNodes: {
-              delta: domNodesEnd.length - domNodesStart.length,
-              deltaPerIteration: (domNodesEnd.length - domNodesStart.length) / numIterations,
-              nodes: leakingDomNodes
-            },
+            domNodes: domNodesSummary,
             collections: leakingCollections
           },
           before: {

--- a/test/spec/domNodes.test.mjs
+++ b/test/spec/domNodes.test.mjs
@@ -87,7 +87,28 @@ describe('dom nodes', () => {
         delta: 3,
         deltaPerIteration: 1
       }
-    ]
-    )
+    ])
+  })
+
+  it('can handle dom nodes leaking with different tag names every time', async () => {
+    const results = await asyncIterableToArray(findLeaks('http://localhost:3000/test/www/domNodesLeakWithNewNames/', {
+      iterations: 3
+    }))
+
+    expect(results.length).to.equal(1)
+    expect(results.map(_ => ({ href: _.test.data.href }))).to.deep.equal([
+      { href: 'about' }
+    ])
+    const result = results[0].result
+    expect(result.leaks.detected).to.equal(true)
+    expect(result.leaks.domNodes.delta).to.equal(3)
+    expect(result.leaks.domNodes.deltaPerIteration).to.equal(1)
+
+    expect(result.before.domNodes.count).to.equal(12)
+    expect(result.after.domNodes.count).to.equal(15)
+
+    expect(result.leaks.domNodes.nodes).to.deep.equal([
+      // TODO: it'd be great to have something here, but it's hard to summarize this situation
+    ])
   })
 })

--- a/test/spec/eventListeners.test.mjs
+++ b/test/spec/eventListeners.test.mjs
@@ -251,4 +251,26 @@ describe('event listeners', () => {
       deltaPerIteration: 0
     })
   })
+
+  it('can handle event listeners leaking where the name changes every time', async () => {
+    const results = await asyncIterableToArray(findLeaks('http://localhost:3000/test/www/listenersLeakWithNewNames/', {
+      iterations: 3
+    }))
+
+    expect(results.length).to.equal(1)
+    expect(results.map(_ => ({ href: _.test.data.href }))).to.deep.equal([
+      { href: 'about' }
+    ])
+    const result = results[0].result
+    expect(result.leaks.detected).to.equal(true)
+    expect(result.leaks.eventListeners).to.deep.equal([
+      // TODO: it would be great to have something here, but it's hard to summarize this situation
+    ])
+    expect(result.leaks.eventListenersSummary).to.deep.equal({
+      before: 4,
+      after: 7,
+      delta: 3,
+      deltaPerIteration: 1
+    })
+  })
 })

--- a/test/www/domNodesLeakWithNewNames/index.html
+++ b/test/www/domNodesLeakWithNewNames/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  router.addAfterHook('/about', () => {
+    const name = `fake-el${Math.round(Math.random() * 1000000).toString(16)}`
+    document.body.appendChild(document.createElement(name))
+  })
+</script>
+</body>
+</html>

--- a/test/www/listenersLeakWithNewNames/index.html
+++ b/test/www/listenersLeakWithNewNames/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module">
+  import { makeRouter } from '../basicRouter.js'
+
+  const router = makeRouter(['', 'about'])
+
+  router.addAfterHook('/about', () => {
+    const name = `fake-${btoa(Math.round(Math.random() * 1000000).toString())}`
+
+    const listener = () => {}
+    document.addEventListener(name, listener)
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
In situations where event listeners or DOM nodes are leaking, but the unique identifiers for those objects (i.e. the names/ids/classes/etc) are constantly changing, the tool doesn't do a great job of summarizing the breakdown. But we should at least print out that a leak is detected.