### PR TITLE
fix: update minimum node version, test in 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.13.1' # minimum supported node version, per package.json "engines" field
+          node-version: '14.14.0' # minimum supported node version, per package.json "engines" field
           cache: 'yarn'
       - run: yarn --immutable
       - run: yarn lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '14.13.1' # minimum supported node version, per package.json "engines" field
           cache: 'yarn'
       - run: yarn --immutable
       - run: yarn lint

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://github.com/nolanlawson/fuite#readme",
   "//": "Require Node 14 and ES modules: https://git.io/JMbBG",
   "engines": {
-    "node": ">= 14.13.1"
+    "node": ">= 14.14.0"
   },
   "volta": {
     "node": "16.13.1",


### PR DESCRIPTION
We should probably test on node 14 since that's our min supported Node version.