### PR TITLE
feat: add --browser-arg option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options:
   -H, --heapsnapshot         Save heapsnapshot files
   -d, --debug                Run in debug mode
   -p, --progress             Show progress spinner (use --no-progress to disable)
+  -b, --browser-arg <arg>    Arg(s) to pass when launching the browser
   -V, --version              output the version number
   -h, --help                 display help for command
 ```
@@ -213,6 +214,19 @@ This will launch Chrome in non-headless mode, and it will also automatically pau
 
 Enable or disable the progress spinner while the test runs. It's true by default, so you should use `--no-progress` to disable.
 
+## Browser args
+
+    -b, --browser-arg <arg>   Arg(s) to pass when launching the browser
+
+This allows you to pass args (aka flags) into Puppeteer when launching the browser. You can define multiple args,
+and they are passed ver batim to [Puppeteer's launch `args` option](https://pptr.dev/#?product=Puppeteer&version=v13.0.1&show=api-puppeteerlaunchoptions).
+
+For example:
+
+```shell
+fuite <url> -b --use-fake-device-for-media-stream -b --enable-experimental-web-platform-features
+```
+
 # JavaScript API
 
 `fuite` can also be used via a JavaScript API, which works similarly to the CLI:
@@ -225,7 +239,8 @@ const results = findLeaks('https://example.com', {
   iterations: 7,
   heapsnapshot: false,
   debug: false,
-  progress: true
+  progress: true,
+  browserArgs: ['--use-fake-device-for-media-stream']
 });
 for await (const result of results) {
   console.log(result);

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,9 @@ const { version } = require('../package.json')
 
 const program = new Command()
 
+// Parse `-b foo -b baz` as ["foo", "baz"], or `-b foo` as ["foo"]
+const parseAsArray = (value, previousValue) => [...(previousValue || []), value]
+
 program
   .argument('<url>', 'URL to load in the browser and analyze')
   .option('-o, --output <file>', 'Write JSON output to a file')
@@ -27,6 +30,7 @@ program
   .option('-S, --setup <setup>', 'Setup function to run (e.g. in the default scenario)')
   .option('-d, --debug', 'Run in debug mode')
   .option('-p, --progress', 'Show progress spinner (--no-progress to disable)', true)
+  .option('-b, --browser-arg <arg>', 'Arg(s) to pass when launching the browser', parseAsArray)
   .version(version)
 program.parse(process.argv)
 const options = program.opts()
@@ -68,7 +72,7 @@ ${chalk.blue('Output')}    : ${outputFilename}
   console.log()
 
   const iterations = parseInt(options.iterations, 10)
-  const { debug, heapsnapshot, progress } = options
+  const { debug, heapsnapshot, progress, browserArg: browserArgs } = options
   console.log(chalk.blue('TEST RESULTS') + '\n\n' + '-'.repeat(20) + '\n')
   let writeCount = 0
   const writeStream = outputFilename && createWriteStream(outputFilename, 'utf8')
@@ -82,7 +86,8 @@ ${chalk.blue('Output')}    : ${outputFilename}
     iterations,
     scenario,
     signal,
-    progress
+    progress,
+    browserArgs
   })
   let numResults = 0
   for await (const result of findLeaksIterable) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,11 @@ async function runOnFreshPage (browser, pageUrl, setup, runnable) {
 
 async function analyzeOptions (options) {
   const { debug, heapsnapshot, progress } = options
+  const args = Array.isArray(options.browserArgs) ? options.browserArgs : []
   const browser = await puppeteer.launch({
     headless: !debug,
-    defaultViewport: { width: 1280, height: 800 }
+    defaultViewport: { width: 1280, height: 800 },
+    args
   })
   if (options.signal) {
     options.signal.addEventListener('abort', () => {


### PR DESCRIPTION
Fixes #39

Unfortunately there isn't a great way to test this, so I'm just adding the feature with no test.

I was going to try a page with CSP and use `--disable-web-security`, but that option seems to have been removed from Chromium. Goes to show how unstable these options are, so there isn't a "well-supported" one that we can reasonably test.