### PR TITLE
fix: remove source-map-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "as-table": "^1.0.55",
+    "atob": "^2.1.2",
     "chalk": "^5.0.1",
     "commander": "^9.0.0",
     "crypto-random-string": "^4.0.0",
@@ -38,7 +39,6 @@
     "puppeteer": "^13.5.1",
     "quick-lru": "^6.1.0",
     "source-map": "^0.7.3",
-    "source-map-resolve": "^0.6.0",
     "stacktrace-parser": "^0.1.10",
     "table": "^6.8.0",
     "temp-dir": "^2.0.0",

--- a/src/resolveSourceMappedPositions.js
+++ b/src/resolveSourceMappedPositions.js
@@ -1,4 +1,4 @@
-import { resolve } from 'source-map-resolve'
+import { resolve } from './thirdparty/source-map-resolve/source-map-resolve.js'
 import { SourceMapConsumer } from 'source-map'
 import { promisify } from 'util'
 import fetch from 'node-fetch'

--- a/src/thirdparty/source-map-resolve/LICENSE
+++ b/src/thirdparty/source-map-resolve/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019, 2020 Simon Lydell
+Copyright (c) 2019 ZHAO Jinxiang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/thirdparty/source-map-resolve/source-map-resolve.js
+++ b/src/thirdparty/source-map-resolve/source-map-resolve.js
@@ -1,0 +1,270 @@
+// Via https://github.com/lydell/source-map-resolve/blob/942b555ea00d10ddd71c894ec1bcda8b49c68be7/index.js
+
+import atob from 'atob'
+import urlLib from 'url'
+
+function resolveUrl(/* ...urls */) {
+  return Array.prototype.reduce.call(arguments, function(resolved, nextUrl) {
+    return urlLib.resolve(resolved, nextUrl)
+  })
+}
+
+function callbackAsync(callback, error, result) {
+  setImmediate(function() { callback(error, result) })
+}
+
+function parseMapToJSON(string, data) {
+  try {
+    return JSON.parse(string.replace(/^\)\]\}'/, ""))
+  } catch (error) {
+    error.sourceMapData = data
+    throw error
+  }
+}
+
+var innerRegex = /[#@] sourceMappingURL=([^\s'"]*)/
+
+var sourceMappingURLRegex = RegExp(
+  "(?:" +
+  "/\\*" +
+  "(?:\\s*\r?\n(?://)?)?" +
+  "(?:" + innerRegex.source + ")" +
+  "\\s*" +
+  "\\*/" +
+  "|" +
+  "//(?:" + innerRegex.source + ")" +
+  ")" +
+  "\\s*"
+)
+
+function getSourceMappingUrl(code) {
+  var match = code.match(sourceMappingURLRegex)
+  return match ? match[1] || match[2] || "" : null
+}
+
+function resolveSourceMap(code, codeUrl, read, callback) {
+  var mapData
+  try {
+    mapData = resolveSourceMapHelper(code, codeUrl)
+  } catch (error) {
+    return callbackAsync(callback, error)
+  }
+  if (!mapData || mapData.map) {
+    return callbackAsync(callback, null, mapData)
+  }
+  var readUrl = decodeURIComponent(mapData.url)
+  read(readUrl, function(error, result) {
+    if (error) {
+      error.sourceMapData = mapData
+      return callback(error)
+    }
+    mapData.map = String(result)
+    try {
+      mapData.map = parseMapToJSON(mapData.map, mapData)
+    } catch (error) {
+      return callback(error)
+    }
+    callback(null, mapData)
+  })
+}
+
+var dataUriRegex = /^data:([^,;]*)(;[^,;]*)*(?:,(.*))?$/
+
+/**
+ * The media type for JSON text is application/json.
+ *
+ * {@link https://tools.ietf.org/html/rfc8259#section-11 | IANA Considerations }
+ *
+ * `text/json` is non-standard media type
+ */
+var jsonMimeTypeRegex = /^(?:application|text)\/json$/
+
+/**
+ * JSON text exchanged between systems that are not part of a closed ecosystem
+ * MUST be encoded using UTF-8.
+ *
+ * {@link https://tools.ietf.org/html/rfc8259#section-8.1 | Character Encoding}
+ */
+var jsonCharacterEncoding = "utf-8"
+
+function base64ToBuf(b64) {
+  var binStr = atob(b64)
+  var len = binStr.length
+  var arr = new Uint8Array(len)
+  for (var i = 0; i < len; i++) {
+    arr[i] = binStr.charCodeAt(i)
+  }
+  return arr
+}
+
+function decodeBase64String(b64) {
+  if (typeof TextDecoder === "undefined" || typeof Uint8Array === "undefined") {
+    return atob(b64)
+  }
+  var buf = base64ToBuf(b64);
+  // Note: `decoder.decode` method will throw a `DOMException` with the
+  // `"EncodingError"` value when an coding error is found.
+  var decoder = new TextDecoder(jsonCharacterEncoding, {fatal: true})
+  return decoder.decode(buf);
+}
+
+function resolveSourceMapHelper(code, codeUrl) {
+  var url = getSourceMappingUrl(code)
+  if (!url) {
+    return null
+  }
+
+  var dataUri = url.match(dataUriRegex)
+  if (dataUri) {
+    var mimeType = dataUri[1] || "text/plain"
+    var lastParameter = dataUri[2] || ""
+    var encoded = dataUri[3] || ""
+    var data = {
+      sourceMappingURL: url,
+      url: null,
+      sourcesRelativeTo: codeUrl,
+      map: encoded
+    }
+    if (!jsonMimeTypeRegex.test(mimeType)) {
+      var error = new Error("Unuseful data uri mime type: " + mimeType)
+      error.sourceMapData = data
+      throw error
+    }
+    try {
+      data.map = parseMapToJSON(
+        lastParameter === ";base64" ? decodeBase64String(encoded) : decodeURIComponent(encoded),
+        data
+      )
+    } catch (error) {
+      error.sourceMapData = data
+      throw error
+    }
+    return data
+  }
+
+  var mapUrl = resolveUrl(codeUrl, url)
+  return {
+    sourceMappingURL: url,
+    url: mapUrl,
+    sourcesRelativeTo: mapUrl,
+    map: null
+  }
+}
+
+function resolveSources(map, mapUrl, read, options, callback) {
+  if (typeof options === "function") {
+    callback = options
+    options = {}
+  }
+  var pending = map.sources ? map.sources.length : 0
+  var result = {
+    sourcesResolved: [],
+    sourcesContent:  []
+  }
+
+  if (pending === 0) {
+    callbackAsync(callback, null, result)
+    return
+  }
+
+  var done = function() {
+    pending--
+    if (pending === 0) {
+      callback(null, result)
+    }
+  }
+
+  resolveSourcesHelper(map, mapUrl, options, function(fullUrl, sourceContent, index) {
+    result.sourcesResolved[index] = fullUrl
+    if (typeof sourceContent === "string") {
+      result.sourcesContent[index] = sourceContent
+      callbackAsync(done, null)
+    } else {
+      var readUrl = decodeURIComponent(fullUrl)
+      read(readUrl, function(error, source) {
+        result.sourcesContent[index] = error ? error : String(source)
+        done()
+      })
+    }
+  })
+}
+
+var endingSlash = /\/?$/
+
+function resolveSourcesHelper(map, mapUrl, options, fn) {
+  options = options || {}
+  var fullUrl
+  var sourceContent
+  var sourceRoot
+  for (var index = 0, len = map.sources.length; index < len; index++) {
+    sourceRoot = null
+    if (typeof options.sourceRoot === "string") {
+      sourceRoot = options.sourceRoot
+    } else if (typeof map.sourceRoot === "string" && options.sourceRoot !== false) {
+      sourceRoot = map.sourceRoot
+    }
+    // If the sourceRoot is the empty string, it is equivalent to not setting
+    // the property at all.
+    if (sourceRoot === null || sourceRoot === '') {
+      fullUrl = resolveUrl(mapUrl, map.sources[index])
+    } else {
+      // Make sure that the sourceRoot ends with a slash, so that `/scripts/subdir` becomes
+      // `/scripts/subdir/<source>`, not `/scripts/<source>`. Pointing to a file as source root
+      // does not make sense.
+      fullUrl = resolveUrl(mapUrl, sourceRoot.replace(endingSlash, "/"), map.sources[index])
+    }
+    sourceContent = (map.sourcesContent || [])[index]
+    fn(fullUrl, sourceContent, index)
+  }
+}
+
+export function resolve(code, codeUrl, read, options, callback) {
+  if (typeof options === "function") {
+    callback = options
+    options = {}
+  }
+  if (code === null) {
+    var mapUrl = codeUrl
+    var data = {
+      sourceMappingURL: null,
+      url: mapUrl,
+      sourcesRelativeTo: mapUrl,
+      map: null
+    }
+    var readUrl = decodeURIComponent(mapUrl)
+    read(readUrl, function(error, result) {
+      if (error) {
+        error.sourceMapData = data
+        return callback(error)
+      }
+      data.map = String(result)
+      try {
+        data.map = parseMapToJSON(data.map, data)
+      } catch (error) {
+        return callback(error)
+      }
+      _resolveSources(data)
+    })
+  } else {
+    resolveSourceMap(code, codeUrl, read, function(error, mapData) {
+      if (error) {
+        return callback(error)
+      }
+      if (!mapData) {
+        return callback(null, null)
+      }
+      _resolveSources(mapData)
+    })
+  }
+
+  function _resolveSources(mapData) {
+    resolveSources(mapData.map, mapData.sourcesRelativeTo, read, options, function(error, result) {
+      if (error) {
+        return callback(error)
+      }
+      mapData.sourcesResolved = result.sourcesResolved
+      mapData.sourcesContent  = result.sourcesContent
+      callback(null, mapData)
+    })
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -825,11 +825,6 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -2931,14 +2926,6 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
-
-source-map-resolve@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
-  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
 
 source-map@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
`source-map-resolve` is deprecated, but I've yet to find a better replacement, so let's just vendor it for now and remove the parts I'm not using.