### PR TITLE
Add optional teardown to scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ export async function createTests(page) {
 export async function iteration(page, data) {
   // Run a single iteration against a page – e.g., click a link and then go back
 }
+
+export async function teardown(page) {
+  // Optional teardown code to run after each test
+}
 ```
 
 Your `myScenario.mjs` can export several `async function`s. Here's what they do:
@@ -159,6 +163,12 @@ Inside of an `iteration`, you want to run the core test logic that you want to t
 - Etc.
 
 The iteration assumes that whatever page it starts at, it ends up at that same page. If you test a multi-page app in this way, then it's extremely unlikely you'll detect any leaks, since multi-page apps don't leak memory in the same way that SPAs do when navigating between routes.
+
+### `teardown` function
+
+The `teardown` function takes a Puppeteer [Page][] as input and returns undefined. It runs after each `iteration`, or after `createTests`.
+
+If this function is not defined, then no teardown code will be run.
 
 ## Setup
 
@@ -280,7 +290,8 @@ For the JavaScript API, you can pass in a custom scenario as a plain object. Fir
 const myScenario = {
   async setup(page) { /* ... */ },
   async createTests(page) { /* ... */ },
-  async iteration(page, data) { /* ... */ }
+  async iteration(page, data) { /* ... */ },
+  async teardown(page) { /* ... */ }
 };
 ```
 

--- a/scenario.mjs
+++ b/scenario.mjs
@@ -1,0 +1,29 @@
+export async function setup(page) {
+  // Setup code to run before each test
+}
+
+export async function createTests(page) {
+  // Code to run once on the page to determine which tests to run
+  console.log('in createTests');
+
+  return Promise.resolve([
+    {
+        "description": "a test",
+        "data": {
+            "foo": 1
+        }
+    }
+  ]);
+}
+
+export async function iteration(page, data) {
+  // Run a single iteration against a page – e.g., click a link and then go back
+  await page.waitForXPath('text=Data.ipynb');
+
+  await page.click('li.jp-DirListing-item[title^="Name: Data.ipynb"]');
+
+  await page.waitForXPath('[role="main"] >> text=Data.ipynb');
+
+  await page.waitForTimeout(200);
+}
+

--- a/scenario.mjs
+++ b/scenario.mjs
@@ -1,29 +1,28 @@
-export async function setup(page) {
+export async function setup (page) {
   // Setup code to run before each test
 }
 
-export async function createTests(page) {
+export async function createTests (page) {
   // Code to run once on the page to determine which tests to run
-  console.log('in createTests');
+  console.log('in createTests')
 
   return Promise.resolve([
     {
-        "description": "a test",
-        "data": {
-            "foo": 1
-        }
+      description: 'a test',
+      data: {
+        foo: 1
+      }
     }
-  ]);
+  ])
 }
 
-export async function iteration(page, data) {
+export async function iteration (page, data) {
   // Run a single iteration against a page – e.g., click a link and then go back
-  await page.waitForXPath('text=Data.ipynb');
+  await page.waitForXPath('text=Data.ipynb')
 
-  await page.click('li.jp-DirListing-item[title^="Name: Data.ipynb"]');
+  await page.click('li.jp-DirListing-item[title^="Name: Data.ipynb"]')
 
-  await page.waitForXPath('[role="main"] >> text=Data.ipynb');
+  await page.waitForXPath('[role="main"] >> text=Data.ipynb')
 
-  await page.waitForTimeout(200);
+  await page.waitForTimeout(200)
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,11 @@ async function runOnFreshPage (browser, pageUrl, setup, runnable, teardown) {
       await waitForPageIdle(page)
     }
     try {
-      return await runnable(page);
+      return await runnable(page)
     } finally {
       if (teardown) {
-        await waitForPageIdle(page);
-        await teardown(page);
+        await waitForPageIdle(page)
+        await teardown(page)
       }
     }
   } finally {

--- a/test/spec/customScenario.test.mjs
+++ b/test/spec/customScenario.test.mjs
@@ -57,7 +57,7 @@ describe('custom scenario', () => {
   })
 
   it('can do a custom scenario with teardown', async () => {
-    let teardownCalled = false;
+    let teardownCalled = false
     const scenario = {
       async iteration (page) {
         await page.click('a[href="info"]')
@@ -66,8 +66,8 @@ describe('custom scenario', () => {
         await page.evaluate(() => new Promise((resolve) => window.requestIdleCallback(resolve)))
       },
       teardown (page) {
-        teardownCalled = true;
-        return Promise.resolve();
+        teardownCalled = true
+        return Promise.resolve()
       }
     }
 
@@ -76,6 +76,7 @@ describe('custom scenario', () => {
       scenario
     }))
 
-    expect(teardownCalled).to.equal(true);
+    expect(results.length).to.equal(1)
+    expect(teardownCalled).to.equal(true)
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@ export declare type Scenario<T> = {
     setup?: (page: Page) => Promise<void>;
     createTests?: (page: Page) => Promise<Array<T>>;
     iteration: (page: Page, options: T) => Promise<void>;
+    teardown?: (page: Page) => Promise<void>;
 };
 export declare type Options = {
     debug?: boolean;


### PR DESCRIPTION
In JupyterLab, some scenarios involves creating some assets on the server before running the monitored code. It will be good to be able to remove those assets to have real identical iterations.

So this PR adds an optional teardown function to scenario.