### PR TITLE
fix: result should have numIterations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,7 @@ function mergeResults (results, numIterations) {
   result.delta = delta
   result.deltaPerIteration = deltaPerIteration
   result.leaks.detected = leaksDetected
+  result.numIterations = numIterations
 
   return result
 }

--- a/test/spec/basic.test.mjs
+++ b/test/spec/basic.test.mjs
@@ -15,6 +15,7 @@ describe('basic test suite', () => {
       { href: 'contact' }
     ])
     expect(results.map(_ => _.result.leaks.detected)).to.deep.equal([true, false, false])
+    expect(results.map(_ => _.result.numIterations)).to.deep.equal([3, 3, 3])
 
     const deltas = results.map(_ => _.result.deltaPerIteration)
     expect(deltas[0]).to.be.above(1000000)


### PR DESCRIPTION
If you run with `--heapsnapshot`, it prints `(undefined iterations)`. This fixes that.