### PR TITLE
fix: fix OOM when collections leak multiple times

### DIFF
--- a/src/metrics/collections/collections.js
+++ b/src/metrics/collections/collections.js
@@ -323,7 +323,7 @@ export async function augmentLeakingCollectionsWithStacktraces (page, collection
     if (collection.id in idsToStacktraces) {
       const stacktraces = idsToStacktraces[collection.id]
       res.stacktraces = (await promisePool(STACKTRACES_PROMISE_POOL_SIZE, stacktraces.map(stacktrace => async () => {
-        return getStacktraceWithOriginalAndPretty(stacktrace)
+        return (await getStacktraceWithOriginalAndPretty(stacktrace))
       })))
     }
     return res

--- a/src/metrics/collections/collections.js
+++ b/src/metrics/collections/collections.js
@@ -322,9 +322,9 @@ export async function augmentLeakingCollectionsWithStacktraces (page, collection
     const res = { ...collection }
     if (collection.id in idsToStacktraces) {
       const stacktraces = idsToStacktraces[collection.id]
-      res.stacktraces = (await promisePool(STACKTRACES_PROMISE_POOL_SIZE, stacktraces.map(stacktrace => async () => {
+      res.stacktraces = await promisePool(STACKTRACES_PROMISE_POOL_SIZE, stacktraces.map(stacktrace => async () => {
         return (await getStacktraceWithOriginalAndPretty(stacktrace))
-      })))
+      }))
     }
     return res
   })))

--- a/test/spec/collections.test.mjs
+++ b/test/spec/collections.test.mjs
@@ -168,4 +168,53 @@ next           webpack://navigo/src/Q.ts:34:10
     const { pretty } = firstCollection.stacktraces[0]
     expect(normalizeStackTrace(pretty)).to.deep.equal(normalizeStackTrace(expected))
   })
+
+  it('collections with lots of leaks', async () => {
+    const results = await asyncIterableToArray(findLeaks('http://localhost:3000/test/www/collectionsWithLotsOfLeaks/', {
+      iterations: 3
+    }))
+
+    const result = results[0].result
+    expect(result.leaks.detected).to.equal(true)
+    expect(result.leaks.collections.length).to.equal(5)
+
+    const firstCollection = result.leaks.collections[0]
+    const {
+      delta,
+      deltaPerIteration,
+      preview,
+      sizeAfter,
+      sizeBefore,
+      type
+    } = firstCollection
+    expect({
+      delta,
+      deltaPerIteration,
+      preview,
+      sizeAfter,
+      sizeBefore,
+      type
+    }).to.deep.equal({
+      delta: 6000,
+      deltaPerIteration: 2000,
+      preview: '[0, ...]',
+      sizeAfter: 8000,
+      sizeBefore: 2000,
+      type: 'Array'
+    })
+
+    const expected = `
+aboutHook      http://localhost:3000/test/www/collectionsWithLotsOfLeaks/script.js:10:18
+               webpack://navigo/src/middlewares/checkForAfterHook.ts:10:52
+Array.forEach  <anonymous>
+forEach        webpack://navigo/src/middlewares/checkForAfterHook.ts:10:36
+context        webpack://navigo/src/Q.ts:31:31
+next           webpack://navigo/src/Q.ts:34:10
+done           webpack://navigo/src/middlewares/callHandler.ts:9:2
+context        webpack://navigo/src/Q.ts:31:31
+next           webpack://navigo/src/Q.ts:34:10
+    `
+    const { pretty } = firstCollection.stacktraces[0]
+    expect(normalizeStackTrace(pretty)).to.deep.equal(normalizeStackTrace(expected))
+  })
 })

--- a/test/www/collectionsWithLotsOfLeaks/index.html
+++ b/test/www/collectionsWithLotsOfLeaks/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<script src="../../../node_modules/navigo/lib/navigo.js"></script>
+<script type="module" src="./script.js"></script>
+</body>
+</html>

--- a/test/www/collectionsWithLotsOfLeaks/script.js
+++ b/test/www/collectionsWithLotsOfLeaks/script.js
@@ -1,0 +1,13 @@
+import { makeRouter } from '../basicRouter.js'
+
+const router = makeRouter(['', 'about'])
+
+const collections = Array(5).fill().map(_ => [])
+
+router.addAfterHook('/about', function aboutHook () {
+  for (const collection of collections) {
+    for (let i = 0; i < 2000; i++) {
+      collection.push(0)
+    }
+  }
+})


### PR DESCRIPTION
Fixes #89.

Turns out we can have an OOM with a small number of collections, if they leak several times. (E.g. an array leaking 2000 items every iteration, with a separate `push()` call for each leak.)