### PR TITLE
fix: check for element visibility in defaultScenario

### DIFF
--- a/src/defaultScenario.js
+++ b/src/defaultScenario.js
@@ -25,6 +25,7 @@ async function clickFirstVisible (page, selector) {
       return el.target === '' &&
         // quick and dirty visibility check
         window.getComputedStyle(el).getPropertyValue('display') !== 'none' &&
+        window.getComputedStyle(el).getPropertyValue('visibility') !== 'hidden' &&
         el.offsetHeight > 0 &&
         el.offsetWidth > 0
     })[0]
@@ -50,6 +51,7 @@ export async function createTests (page) {
         return el.target === '' &&
           // quick and dirty visibility check
           window.getComputedStyle(el).getPropertyValue('display') !== 'none' &&
+          window.getComputedStyle(el).getPropertyValue('visibility') !== 'hidden' &&
           el.offsetHeight > 0 &&
           el.offsetWidth > 0
       })

--- a/test/www/invisibleLinks/index.html
+++ b/test/www/invisibleLinks/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
 </head>
 <body>
-<a href="yolo" style="display:none">Yolo</a>
-<a href="faux" style="display:none">Faux</a>
+<a href="about" style="display:none">About</a>
+<a href="about" style="display:none">About</a>
 <a href="fake" style="display:none">Fake</a>
 <a href="alsoFake" style="visibility:hidden">Also fake</a>
 <a href="yepFake" style="width:0;height:0;display:block;">Yep fake</a>

--- a/test/www/invisibleLinks/index.html
+++ b/test/www/invisibleLinks/index.html
@@ -4,9 +4,11 @@
   <meta charset="UTF-8">
 </head>
 <body>
-<a href="about" style="display:none">About</a>
-<a href="about" style="display:none">About</a>
+<a href="yolo" style="display:none">Yolo</a>
+<a href="faux" style="display:none">Faux</a>
 <a href="fake" style="display:none">Fake</a>
+<a href="alsoFake" style="visibility:hidden">Also fake</a>
+<a href="yepFake" style="width:0;height:0;display:block;">Yep fake</a>
 <script src="../../../node_modules/navigo/lib/navigo.js"></script>
 <script type="module">
   import { makeRouter } from '../basicRouter.js'


### PR DESCRIPTION
This is just something annoying I've noticed on a particular site. It uses `visibility: hidden` for some anchor elements. We should detect that.