### PR TITLE
fix: use built-in crypto.randomUUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "source-map": "^0.7.4",
     "stacktrace-parser": "^0.1.10",
     "table": "^6.8.2",
-    "temp-dir": "^3.0.0",
-    "uuid": "^10.0.0"
+    "temp-dir": "^3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       temp-dir:
         specifier: ^3.0.0
         version: 3.0.0
-      uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.7
@@ -2306,10 +2303,6 @@ packages:
 
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -4895,8 +4888,6 @@ snapshots:
       punycode: 2.3.1
 
   urlpattern-polyfill@10.0.0: {}
-
-  uuid@10.0.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/src/metrics/domNodesAndListeners/eventListeners.js
+++ b/src/metrics/domNodesAndListeners/eventListeners.js
@@ -1,11 +1,11 @@
-import { v4 as uuidV4 } from 'uuid'
+import { randomUUID } from 'node:crypto'
 import { omit, pick } from '../../util.js'
 import { getDescriptors } from '../../getDescriptors.js'
 import { getAllDomNodes } from '../../browser/getAllDomNodes.js'
 
 // via https://stackoverflow.com/a/67030384
 export async function getDomNodesAndListeners (page, cdpSession) {
-  const objectGroup = uuidV4()
+  const objectGroup = randomUUID()
   const { result: { objectId } } = await cdpSession.send('Runtime.evaluate', {
     expression: `
         (function () {


### PR DESCRIPTION
I realized we can just get rid of `uuid` entirely; the `crypto` API is available in all our supported Node versions, and apparently [it's faster](https://dev.to/galkin/crypto-randomuuid-vs-uuid-v4-47i5).